### PR TITLE
Фикс зависающих тестов

### DIFF
--- a/backend/eqator/checks.py
+++ b/backend/eqator/checks.py
@@ -87,7 +87,7 @@ def check_unit_tests(directory: str, verbose: bool, config_file: str, tests: boo
             print_default('Django unit tests')
 
             if check_needed(test_coverage, variables_passed):
-                shell_run(f'{command_pref}{directory}/manage.py test')
+                shell_run(f'{command_pref}{directory}/manage.py test --noinput')
 
             failures, output = run_unit_tests(config_file, ())
 

--- a/backend/eqator/helpers.py
+++ b/backend/eqator/helpers.py
@@ -13,6 +13,7 @@ from .colors import BOLD
 def print_default(text=''):
     sys.stdout.write(RESET)
     sys.stdout.write(f'  {text}')
+    sys.stdout.flush()
 
 
 def print_ok(lines='', verbose=False):


### PR DESCRIPTION
Иногда, во время выполнения `qa` она зависает. Это было связано с тем, что ранее выполнение данной команды было прервано с клавиатуры, поэтому команда `manage.py test` не была выполнена полностью, из-за чего тестовая БД не была удалена. Поэтому, при следующем запуске от пользователя нужно ручное подтверждение удаления БД.

1. Добавлен аргумент `--noinput` при вызове `manage.py test`. Благодаря этому параметру старая тестовая БД будет автоматически пересоздаваться, не спрашивая юзера об этом, тем самым не вешая сабпроцесс.
2. `sys.stdout.flush()` был добавлен, чтобы было понимание, когда та или иная проверка начала свою работу. Т.е раньше название проверки (например, "Django unit tests" и её статус (OK, Failed)) выводились одновременно из-за stdout буффера. Сейчас это разделено, поэтому при старте тестов будет выведено "Django unit tests", а после окончания "OK"/"Failed"